### PR TITLE
Fix subreddit name length

### DIFF
--- a/commands/subreddit.js
+++ b/commands/subreddit.js
@@ -27,7 +27,7 @@ class SubredditCommand extends Command {
     }
     
     respond(message, bot, config, resolve, reject) {
-        let subredditRegex = /\b\/?r\/([A-Za-z_0-9]{1,28})/gm;
+        let subredditRegex = /\b\/?r\/([A-Za-z_0-9]{3,28})/gm;
         
         let matches = [];
         let match;


### PR DESCRIPTION
changed regex to match 3 characters instead of just one as subreddit names are always at least three characters long as in https://github.com/ImperialNewsNetwork/inn-bot/issues/9